### PR TITLE
Fixed broken link on Stats and Data Science page

### DIFF
--- a/catalog.stolaf.edu/academic-programs/statistics/index.html
+++ b/catalog.stolaf.edu/academic-programs/statistics/index.html
@@ -387,7 +387,7 @@ else {
 <p class="body">At St. Olaf, students can combine their interests in statistics with any major and acquire a background that leads to graduate study and abundant career opportunities. To find out more about the statistics concentration, visit the <a href="http://wp.stolaf.edu/statistics/" target="_blank">Statistics program</a>.</p>
 </div>
 <div>
-<h2 class="goldhead" headerid="2" name="text"><a href="http://wp.stolaf.edu/curriculum-committee/statistics-concentration-ilos/" target="_blank">Intended Learning Outcomes for the Concentration</a></h2>
+<h2 class="goldhead" headerid="2" name="text"><a href="https://wp.stolaf.edu/curriculum-committee/statistics-and-data-science-concentration-ilos/" target="_blank">Intended Learning Outcomes for the Concentration</a></h2>
 </div></div><!--end #textcontainer -->
 
 			<div id="requirementstextcontainer" class="tab_content" role="tabpanel">


### PR DESCRIPTION
The link on stats and data science page didn't work so I linked it to the correct page. The correct page is the https://wp.stolaf.edu/curriculum-committee/statistics-and-data-science-concentration-ilos/.